### PR TITLE
Expand Admin UI

### DIFF
--- a/app/admin/batch_job.rb
+++ b/app/admin/batch_job.rb
@@ -1,0 +1,58 @@
+ActiveAdmin.register BatchJob do
+
+  ## Disable new and create
+  actions :all, except: [:new, :create]
+
+  ## Permit attributes to be updated
+  permit_params :job_type, :ocr_engine, :parameters, :name, :notes, :font
+
+  ## Controller customizations
+  controller do
+    skip_before_filter :get_dropdown_data
+  end
+
+  ## Index search filters
+  filter :id
+  filter :name
+  filter :job_type
+  filter :ocr_engine
+  filter :font
+
+  ## INDEX
+  index do
+    selectable_column
+    id_column
+    column :name
+    column :job_type
+    column :ocr_engine
+    column :font
+    actions
+  end
+
+  ## SHOW
+  show do
+    attributes_table do
+      row :id
+      row :name
+      row :job_type
+      row :ocr_engine
+      row :font
+      row :parameters
+      row :notes
+    end
+  end
+
+  ## EDIT / UPDATE
+  form do |f|
+    f.semantic_errors
+    f.inputs do
+      f.input :name
+      f.input :job_type
+      f.input :ocr_engine
+      f.input :font
+      f.input :parameters
+      f.input :notes
+    end
+    f.actions
+  end
+end

--- a/app/admin/job_queue.rb
+++ b/app/admin/job_queue.rb
@@ -1,0 +1,94 @@
+ActiveAdmin.register JobQueue do
+
+  ## Disable new, create, edit, update and destroy
+  actions :all, except: [:new, :create, :edit, :update, :destroy]
+
+  ## Permit these attributes to be updated - unneeded since actions are disabled
+  #permit_params :status, :proc_id
+
+  ## Batch Actions
+  batch_action :destroy, false #TODO: Reevaluate if we want this disabled
+  batch_action :mark_not_started, confirm: "Are you sure you want to mark Not Started?" do |ids|
+    JobQueue.find(ids).each do |job_queue|
+      job_queue.mark_not_started!
+    end
+
+    redirect_to collection_path, alert: "The job queues have been marked Not Started."
+  end
+  
+  batch_action :mark_failed, confirm: "Are you sure you want to mark Failed?" do |ids|
+    JobQueue.find(ids).each do |job_queue|
+      job_queue.mark_failed!
+    end
+
+    redirect_to collection_path, alert: "The job queues have been marked Failed."
+  end
+
+  ## Custom Actions - this setups the controller action
+  member_action :mark_not_started, method: :put do
+    resource.mark_not_started!
+    redirect_to resource_path, notice: "Marked Not Started!"
+  end
+
+  member_action :mark_failed, method: :put do
+    resource.mark_failed!
+    redirect_to resource_path, notice: "Marked Failed!"
+  end
+
+  ## Action Items - this adds the buttons to pages like Show
+  action_item :mark_not_started, only: :show do
+    link_to "Mark Not Started", mark_not_started_admin_job_queue_path(job_queue), method: :put
+  end
+
+  action_item :mark_failed, only: :show do
+    link_to "Mark Failed", mark_failed_admin_job_queue_path(job_queue), method: :put
+  end
+
+  ## Controller customizations
+  controller do
+    skip_before_filter :get_dropdown_data
+  end
+
+  ## Index search filters
+  filter :id
+  filter :status
+  filter :proc_id
+  filter :batch_job
+
+  ## INDEX
+  index do
+    selectable_column
+    id_column
+    column :status
+    column :proc_id
+    actions do |job_queue|
+      # Must concatinate the links for both to show up.  May change as ActiveAdmin improves
+      link_to("Mark Not Started", mark_not_started_admin_job_queue_path(job_queue), class: "member_link", method: :put) +
+      link_to("Mark Failed", mark_failed_admin_job_queue_path(job_queue), class: "member_link", method: :put)
+   end
+  end
+
+  ## SHOW
+  show do
+    attributes_table do
+      row :id
+      row :status do
+        job_queue.status.name
+      end
+      row :proc_id
+      row :tries
+      row :results
+      row :batch_job do
+        job_queue.batch_job.id
+      end
+      row :page do
+        job_queue.page.id
+      end
+      row :work do
+        link_to "Work ##{job_queue.work.id}", admin_work_path(job_queue.work)
+      end
+      row :created
+      row :last_update
+    end
+  end
+end

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -1,7 +1,9 @@
 ActiveAdmin.register User do
 
+  ## Permit these attributes to be updated
   permit_params :email, :password, :password_confirmation
 
+  ## Controller customizations
   controller do
     skip_before_filter :get_dropdown_data
 
@@ -15,8 +17,10 @@ ActiveAdmin.register User do
     end
   end
 
+  ## Index search filters
   filter :email
 
+  ## INDEX
   index do
     id_column
     column :email
@@ -26,6 +30,7 @@ ActiveAdmin.register User do
     actions
   end
 
+  ## NEW / EDIT
   form do |f|
     f.semantic_errors
     f.inputs do

--- a/app/admin/work.rb
+++ b/app/admin/work.rb
@@ -1,21 +1,32 @@
 ActiveAdmin.register Work do
 
+  ## Disable new, create, edit, update and destroy
+  actions :all, except: [:new, :create, :destroy]
+
+  ## Permit these attributes to be updated
   permit_params :wks_tcp_number, :wks_estc_number, :wks_tcp_bibno, :wks_marc_record, :wks_eebo_citation_id, :wks_eebo_directory,
                 :wks_ecco_number, :wks_book_id, :wks_author, :wks_publisher, :wks_word_count, :wks_title, :wks_eebo_image_id, :wks_eebo_url, :wks_pub_date,
                 :wks_ecco_uncorrected_gale_ocr_path, :wks_ecco_corrected_xml_path, :wks_ecco_corrected_text_path, :wks_ecco_directory, :wks_ecco_gale_ocr_xml_path,
                 :wks_organizational_unit, :wks_primary_print_font
 
+  ## Controller customizations
   controller do
     skip_before_filter :get_dropdown_data
   end
 
+  ## Index search filters
   filter :wks_tcp_number
   filter :wks_estc_number
+  filter :wks_ecco_number
+  filter :wks_eebo_image_id
 
+  ## INDEX
   index do
     id_column
     column :wks_tcp_number
     column :wks_estc_number
+    column :wks_ecco_number
+    column :wks_eebo_image_id
     actions
   end
 end

--- a/app/models/batch_job.rb
+++ b/app/models/batch_job.rb
@@ -4,10 +4,9 @@ class BatchJob < ActiveRecord::Base
   belongs_to :font
   belongs_to :ocr_engine
   belongs_to :job_type
-  has_many :job_queues, foreign_key: 'batch_id'
-  has_many :page_results, foreign_key: 'batch_id'
-  has_many :postproc_pages
-  has_many :postprocesses, through: :postproc_pages
+  has_many :job_queues, foreign_key: 'batch_id', dependent: :destroy
+  has_many :page_results, foreign_key: 'batch_id', dependent: :destroy
+  has_many :postproc_pages, dependent: :destroy
   has_many :work_ocr_results
   has_many :ocr_results, through: :work_ocr_results
 

--- a/app/models/font.rb
+++ b/app/models/font.rb
@@ -27,4 +27,9 @@ class Font < ActiveRecord::Base
   def id
     read_attribute(:font_id)
   end
+
+  #TODO: Remove once schema is sane
+  def name
+    read_attribute(:font_name)
+  end
 end

--- a/app/models/job_queue.rb
+++ b/app/models/job_queue.rb
@@ -32,6 +32,14 @@ class JobQueue < ActiveRecord::Base
     write_attribute(:results, new_value)
   end
 
+  def mark_not_started!
+    update(proc_id: nil, status: JobStatus.find_by_name('Not Started'))
+  end
+
+  def mark_failed!
+    update(results: "Marked failed using dashboard.", status: JobStatus.find_by_name("Failed"))
+  end
+
   def self.unreserved
     @job_status = JobStatus.find_by_name('Not Started')
     where(proc_id: nil, job_status_id: @job_status.id)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,3 +21,9 @@
 
 en:
   hello: "Hello world"
+  active_admin:
+    batch_actions:
+      action_label: "%{title}"
+      labels:
+        mark_not_started: "Mark Not Started"
+        mark_failed: "Mark Failed"

--- a/spec/admin/batch_job_spec.rb
+++ b/spec/admin/batch_job_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe 'BatchJob' do
+  let(:resource_class) { BatchJob }
+  let(:all_resources)  { ActiveAdmin.application.namespaces[:admin].resources }
+  let(:resource)       { all_resources[resource_class] }
+
+  it "should be a resource" do
+    expect(resource.resource_name).to eq('BatchJob')
+  end
+
+  it 'should have actions' do
+    expect(resource.defined_actions).to include(:update, :index, :show, :edit, :destroy)
+  end
+
+  it 'should not have new or create actions' do
+    expect(resource.defined_actions).to_not include(:new, :create)
+  end
+
+  it 'should have batch_actions' do
+    expect(resource.batch_actions.map(&:sym)).to include(:destroy)
+  end
+end

--- a/spec/admin/job_queue_spec.rb
+++ b/spec/admin/job_queue_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe 'JobQueue' do
+  let(:resource_class) { JobQueue }
+  let(:all_resources)  { ActiveAdmin.application.namespaces[:admin].resources }
+  let(:resource)       { all_resources[resource_class] }
+
+  it "should be a resource" do
+    expect(resource.resource_name).to eq('JobQueue')
+  end
+
+  it 'should have actions' do
+    expect(resource.defined_actions).to include(:index, :show)
+  end
+
+  it 'should not have new or create actions' do
+    expect(resource.defined_actions).to_not include(:new, :create, :edit, :update, :destroy)
+  end
+
+  it 'should have batch_actions' do
+    expect(resource.batch_actions.map(&:sym)).to include(:mark_not_started, :mark_failed)
+  end
+
+  it 'should have batch_action destroy' do
+    expect(resource.batch_actions.map(&:sym)).to_not include(:destroy)
+  end
+
+  it 'should have member_actions' do
+    expect(resource.member_actions.map(&:name)).to include(:mark_not_started, :mark_failed)
+  end
+end

--- a/spec/admin/work_spec.rb
+++ b/spec/admin/work_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe 'Work' do
   end
 
   it 'should have actions' do
-    expect(resource.defined_actions).to include(:update, :index, :show, :new, :edit, :create, :destroy)
+    expect(resource.defined_actions).to include(:update, :index, :show, :edit)
+  end
+
+  it 'should not have new or create actions' do
+    expect(resource.defined_actions).to_not include(:new, :create, :destroy)
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -95,7 +95,7 @@ FactoryGirl.define do
     juxta_change_index 0.0
     alt_change_index 0.0
 
-    after(:build) do |p|
+    after(:create) do |p|
       p.page = create(:page)
       p.batch_job = create(:batch_job)
     end
@@ -114,7 +114,7 @@ FactoryGirl.define do
     multicol '0;1;2'
     skew_idx '1;0;1'
 
-    after(:build) do |p|
+    after(:create) do |p|
       p.page = create(:page)
       p.batch_job = create(:batch_job)
     end

--- a/spec/models/batch_job_spec.rb
+++ b/spec/models/batch_job_spec.rb
@@ -7,6 +7,32 @@ RSpec.describe BatchJob, :type => :model do
     expect(batch_job).to be_valid
   end
 
+  describe "dependent :destroy" do
+    it "should destroy associated job_queues" do
+      job_queue = create(:job_queue, batch_job: batch_job)
+      expect(batch_job.job_queues.present?).to be true
+      expect(JobQueue.find(job_queue.id)).to_not be_nil
+      batch_job.destroy!
+      expect { JobQueue.find(job_queue.id) }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "should destroy associated page_results" do
+      page_result = create(:page_result, batch_job: batch_job)
+      expect(batch_job.page_results.present?).to be true
+      expect(PageResult.find(page_result.id)).to_not be_nil
+      batch_job.destroy!
+      expect { PageResult.find(page_result.id) }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "should destroy associated postproc_pages" do
+      postproc_page = create(:postproc_page, batch_job: batch_job)
+      expect(batch_job.postproc_pages.present?).to be true
+      expect(PostprocPage.find(postproc_page.id)).to_not be_nil
+      batch_job.destroy!
+      expect { PostprocPage.find(postproc_page.id) }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
   describe "set_defaults" do
     let(:batch_job) { BatchJob.new }
 

--- a/spec/models/job_queue_spec.rb
+++ b/spec/models/job_queue_spec.rb
@@ -42,6 +42,25 @@ RSpec.describe JobQueue, :type => :model do
     end
   end
 
+  describe "mark_not_started!" do
+    it "resets proc_id and status" do
+      job_queue = create(:job_queue, status: JobStatus.processing, proc_id: '000001')
+      job_queue.mark_not_started!
+      expect(job_queue.proc_id).to be_nil
+      expect(job_queue.status).to eq(JobStatus.not_started)
+    end
+  end
+
+  describe "mark_failed!" do
+    it "sets status to failed" do
+      job_queue = create(:job_queue, status: JobStatus.processing, proc_id: '000001')
+      job_queue.mark_failed!
+      expect(job_queue.proc_id).to eq('000001')
+      expect(job_queue.status).to eq(JobStatus.failed)
+      expect(job_queue.results).to eq("Marked failed using dashboard.")
+    end
+  end
+
   describe "#status_summary" do
     it "should generate status counts" do
       create_list(:job_queue, 2, status: JobStatus.not_started)

--- a/spec/requests/api/v1/batch_jobs_spec.rb
+++ b/spec/requests/api/v1/batch_jobs_spec.rb
@@ -74,8 +74,8 @@ RSpec.describe Api::V1::BatchJobsController, :type => :request do
     it 'uploads page and postproc page results', :show_in_doc do
       completed_job_queues = create_list(:job_queue, 5, status: JobStatus.processing)
       failed_job_queues = create_list(:job_queue, 2, status: JobStatus.processing)
-      page_result = build_attributes(:page_result)
-      postproc_page = build_attributes(:postproc_page)
+      page_result = build_attributes(:page_result, batch_job: create(:batch_job), page: create(:page))
+      postproc_page = build_attributes(:postproc_page, batch_job: create(:batch_job), page: create(:page))
 
       data = {
         job_queues: {


### PR DESCRIPTION
- Add management of BatchJob and JobQueue to admin interface
  *\* This is a partial solution to #10
- Remove new, create and destroy actions from Work admin interface
- Add extra filters and columns to Work admin interface
- Update BatchJob model so dependent records (JobQueue, PageResult, PostprocPage) are destroyed when the associated BatchJob is destroyed
- Add name virtual attribute to Font model which helps ActiveAdmin correctly assign labels in the interface
